### PR TITLE
[Feat] 온보딩 편지 화면 전환

### DIFF
--- a/Deartoday/Deartoday.xcodeproj/project.pbxproj
+++ b/Deartoday/Deartoday.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4A45D37E287F0B2F00592749 /* OpenBoxOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A45D37D287F0B2F00592749 /* OpenBoxOnboardingViewController.swift */; };
 		4A706264287C079F00140315 /* Onboarding.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4A706263287C079F00140315 /* Onboarding.storyboard */; };
 		923061D4287754DB00F04EDA /* TimeTravelDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923061D3287754DB00F04EDA /* TimeTravelDataModel.swift */; };
 		923061D6287754FA00F04EDA /* TimeTravelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923061D5287754FA00F04EDA /* TimeTravelView.swift */; };
@@ -72,6 +73,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4A45D37D287F0B2F00592749 /* OpenBoxOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenBoxOnboardingViewController.swift; sourceTree = "<group>"; };
 		4A706263287C079F00140315 /* Onboarding.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Onboarding.storyboard; sourceTree = "<group>"; };
 		6117E07E0B8313B67F3D1573 /* Pods-Deartoday.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Deartoday.debug.xcconfig"; path = "Target Support Files/Pods-Deartoday/Pods-Deartoday.debug.xcconfig"; sourceTree = "<group>"; };
 		91A3CEAB5A8D31B890C8B41E /* Pods_Deartoday.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Deartoday.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -367,6 +369,7 @@
 			isa = PBXGroup;
 			children = (
 				92DB35652875652F001E2006 /* OnboardingViewController.swift */,
+				4A45D37D287F0B2F00592749 /* OpenBoxOnboardingViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -735,6 +738,7 @@
 				92DB3570287565E4001E2006 /* UILabel+.swift in Sources */,
 				92DB358828756B7D001E2006 /* TempService.swift in Sources */,
 				92DB358028756AE8001E2006 /* MoyaLoggingPlugin.swift in Sources */,
+				4A45D37E287F0B2F00592749 /* OpenBoxOnboardingViewController.swift in Sources */,
 				92CC3B9C287CA17000EA5617 /* CountDownLabel.swift in Sources */,
 				923061D4287754DB00F04EDA /* TimeTravelDataModel.swift in Sources */,
 				92DB35312875633D001E2006 /* AppDelegate.swift in Sources */,

--- a/Deartoday/Deartoday.xcodeproj/project.pbxproj
+++ b/Deartoday/Deartoday.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4A45D37E287F0B2F00592749 /* OpenBoxOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A45D37D287F0B2F00592749 /* OpenBoxOnboardingViewController.swift */; };
+		4A45D380287F2BF800592749 /* LetterOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A45D37F287F2BF800592749 /* LetterOnboardingViewController.swift */; };
 		4A706264287C079F00140315 /* Onboarding.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4A706263287C079F00140315 /* Onboarding.storyboard */; };
 		923061D4287754DB00F04EDA /* TimeTravelDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923061D3287754DB00F04EDA /* TimeTravelDataModel.swift */; };
 		923061D6287754FA00F04EDA /* TimeTravelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923061D5287754FA00F04EDA /* TimeTravelView.swift */; };
@@ -74,6 +75,7 @@
 
 /* Begin PBXFileReference section */
 		4A45D37D287F0B2F00592749 /* OpenBoxOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenBoxOnboardingViewController.swift; sourceTree = "<group>"; };
+		4A45D37F287F2BF800592749 /* LetterOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterOnboardingViewController.swift; sourceTree = "<group>"; };
 		4A706263287C079F00140315 /* Onboarding.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Onboarding.storyboard; sourceTree = "<group>"; };
 		6117E07E0B8313B67F3D1573 /* Pods-Deartoday.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Deartoday.debug.xcconfig"; path = "Target Support Files/Pods-Deartoday/Pods-Deartoday.debug.xcconfig"; sourceTree = "<group>"; };
 		91A3CEAB5A8D31B890C8B41E /* Pods_Deartoday.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Deartoday.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -370,6 +372,7 @@
 			children = (
 				92DB35652875652F001E2006 /* OnboardingViewController.swift */,
 				4A45D37D287F0B2F00592749 /* OpenBoxOnboardingViewController.swift */,
+				4A45D37F287F2BF800592749 /* LetterOnboardingViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -752,6 +755,7 @@
 				92DB35582875646E001E2006 /* OnboardingModel.swift in Sources */,
 				98BFBCCF2879B85400F01F04 /* UIFont+.swift in Sources */,
 				92DB357A28756A61001E2006 /* URLConstant.swift in Sources */,
+				4A45D380287F2BF800592749 /* LetterOnboardingViewController.swift in Sources */,
 				92DB356E287565AC001E2006 /* UIScreen+.swift in Sources */,
 				98B4B5AA287EB54600F4AD7A /* ViewController.swift in Sources */,
 				98D912D2287DC3590088A7F9 /* CheckMessageDataModel.swift in Sources */,

--- a/Deartoday/Deartoday/Global/Constant/ViewController.swift
+++ b/Deartoday/Deartoday/Global/Constant/ViewController.swift
@@ -12,6 +12,7 @@ extension Constant {
         ///온보딩
         static let Onboarding = "OnboardingViewController"
         static let OpenBoxOnboarding = "OpenBoxOnboardingViewController"
+        static let LetterOnboarding = "LetterOnboardingViewController"
         
         ///메인
         static let Main = "MainViewController"

--- a/Deartoday/Deartoday/Global/Constant/ViewController.swift
+++ b/Deartoday/Deartoday/Global/Constant/ViewController.swift
@@ -11,6 +11,7 @@ extension Constant {
     struct ViewController {
         ///온보딩
         static let Onboarding = "OnboardingViewController"
+        static let OpenBoxOnboarding = "OpenBoxOnboardingViewController"
         
         ///메인
         static let Main = "MainViewController"

--- a/Deartoday/Deartoday/Screen/Onboarding/Controller/LetterOnboardingViewController.swift
+++ b/Deartoday/Deartoday/Screen/Onboarding/Controller/LetterOnboardingViewController.swift
@@ -1,0 +1,16 @@
+//
+//  LetterOnboardingViewController.swift
+//  Deartoday
+//
+//  Created by 황찬미 on 2022/07/14.
+//
+
+import UIKit
+
+class LetterOnboardingViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+}

--- a/Deartoday/Deartoday/Screen/Onboarding/Controller/OnboardingViewController.swift
+++ b/Deartoday/Deartoday/Screen/Onboarding/Controller/OnboardingViewController.swift
@@ -34,7 +34,10 @@ final class OnboardingViewController: UIViewController {
     // MARK: - @objc
     
     @objc func circleButtonDidTap() {
-        print("로티")
+        guard let openBoxOnboarding = self.storyboard?.instantiateViewController(withIdentifier: Constant.ViewController.OpenBoxOnboarding) else { return }
+        openBoxOnboarding.modalPresentationStyle = .fullScreen
+        openBoxOnboarding.modalTransitionStyle = .crossDissolve
+        self.present(openBoxOnboarding, animated: true)
     }
     
     // MARK: - Custom Method
@@ -106,9 +109,5 @@ final class OnboardingViewController: UIViewController {
         hideComponents()
         setSecondAnimation()
         showComponents()
-    }
-    
-    @IBAction func boxButtonDidTap(_ sender: UIButton) {
-        print("로티")
     }
 }

--- a/Deartoday/Deartoday/Screen/Onboarding/Controller/OnboardingViewController.swift
+++ b/Deartoday/Deartoday/Screen/Onboarding/Controller/OnboardingViewController.swift
@@ -34,7 +34,8 @@ final class OnboardingViewController: UIViewController {
     // MARK: - @objc
     
     @objc func circleButtonDidTap() {
-        guard let openBoxOnboarding = self.storyboard?.instantiateViewController(withIdentifier: Constant.ViewController.OpenBoxOnboarding) else { return }
+        guard let openBoxOnboarding = UIStoryboard(name: Constant.Storyboard.Onboarding, bundle: nil).instantiateViewController(withIdentifier: Constant.ViewController.OpenBoxOnboarding) as? OpenBoxOnboardingViewController else { return }
+        
         openBoxOnboarding.modalPresentationStyle = .fullScreen
         openBoxOnboarding.modalTransitionStyle = .crossDissolve
         self.present(openBoxOnboarding, animated: true)

--- a/Deartoday/Deartoday/Screen/Onboarding/Controller/OnboardingViewController.swift
+++ b/Deartoday/Deartoday/Screen/Onboarding/Controller/OnboardingViewController.swift
@@ -81,15 +81,15 @@ final class OnboardingViewController: UIViewController {
             self.labelCollection[0].transform = CGAffineTransform(translationX: 0, y: -16)
             self.labelCollection[0].alpha = 1
         }, completion: { _ in
-                       UIView.animate(withDuration: 0.5, delay: 0.5, animations: {
-            self.labelCollection[1].transform = CGAffineTransform(translationX: 0, y: -16)
-            self.labelCollection[1].alpha = 1
-                       }, completion: { _ in
-                           UIView.animate(withDuration: 0.3, delay: 0.3, animations: {
-                               self.nextButton.alpha = 1
-                           }, completion: nil )
-                       })
-    })
+            UIView.animate(withDuration: 0.5, delay: 0.5, animations: {
+                self.labelCollection[1].transform = CGAffineTransform(translationX: 0, y: -16)
+                self.labelCollection[1].alpha = 1
+            }, completion: { _ in
+                UIView.animate(withDuration: 0.3, delay: 0.3, animations: {
+                    self.nextButton.alpha = 1
+                }, completion: nil )
+            })
+        })
     }
     
     private func setSecondAnimation() {

--- a/Deartoday/Deartoday/Screen/Onboarding/Controller/OpenBoxOnboardingViewController.swift
+++ b/Deartoday/Deartoday/Screen/Onboarding/Controller/OpenBoxOnboardingViewController.swift
@@ -12,12 +12,20 @@ class OpenBoxOnboardingViewController: UIViewController {
     // MARK: - UI Property
     @IBOutlet var labelCollection: [UILabel]!
     @IBOutlet weak var letterButton: UIButton!
+    @IBOutlet weak var labelBottomConstraint: NSLayoutConstraint!
     
     // MARK: - Life Cycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
+        setLayout()
+    }
+    
+    // MARK: - Custom Method
+    
+    private func setLayout() {
+        labelBottomConstraint.constant = (getDeviceHeight() == 667) ? 20 : 44
     }
     
     // MARK: - Component UI Setting functions

--- a/Deartoday/Deartoday/Screen/Onboarding/Controller/OpenBoxOnboardingViewController.swift
+++ b/Deartoday/Deartoday/Screen/Onboarding/Controller/OpenBoxOnboardingViewController.swift
@@ -1,0 +1,66 @@
+//
+//  OpenBoxOnboardingViewController.swift
+//  Deartoday
+//
+//  Created by 황찬미 on 2022/07/13.
+//
+
+import UIKit
+
+class OpenBoxOnboardingViewController: UIViewController {
+
+    // MARK: - UI Property
+    @IBOutlet var labelCollection: [UILabel]!
+    @IBOutlet weak var letterButton: UIButton!
+    
+    // MARK: - Life Cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUI()
+    }
+    
+    // MARK: - Component UI Setting functions
+    
+    private func setUI() {
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.setComponentsAnimation()
+        }
+        
+        labelCollection.forEach {
+            $0.textColor = .white
+            $0.font = .p1
+            $0.font = .systemFont(ofSize: 13)
+        }
+        
+        labelCollection.forEach {
+            $0.isHidden = false
+        }
+        
+        letterButton.isHidden = false
+    }
+    
+    // MARK: - Animation function
+    
+    private func setComponentsAnimation() {
+        UIView.animate(withDuration: 0.5, animations: {
+            self.labelCollection[0].transform = CGAffineTransform(translationX: 0, y: -16)
+            self.labelCollection[0].alpha = 1
+        }, completion: { _ in
+            UIView.animate(withDuration: 0.5, delay: 0.5, animations: {
+                self.labelCollection[1].transform = CGAffineTransform(translationX: 0, y: -16)
+                self.labelCollection[1].alpha = 1
+            }, completion: { _ in
+                UIView.animate(withDuration: 0.5, delay: 0.5, animations: {
+                    self.labelCollection[2].transform = CGAffineTransform(translationX: 0, y: -16)
+                    self.labelCollection[2].alpha = 1
+                }, completion: { _ in
+                    UIView.animate(withDuration: 0.3, delay: 0.3, animations: {
+                        self.letterButton.alpha = 1
+                    }, completion: nil )
+                })
+            })
+        })
+    }
+}

--- a/Deartoday/Deartoday/Screen/Onboarding/Controller/OpenBoxOnboardingViewController.swift
+++ b/Deartoday/Deartoday/Screen/Onboarding/Controller/OpenBoxOnboardingViewController.swift
@@ -42,17 +42,14 @@ final class OpenBoxOnboardingViewController: UIViewController {
         letterButton.isHidden = false
     }
     
-    private func hideComponents() {
+    // MARK: - IBAction
+    
+    @IBAction func letterButtonDidTap(_ sender: UIButton) {
         labelCollection.forEach {
             $0.isHidden = true
         }
         letterButton.isHidden = true
-    }
-    
-    // MARK: - IBAction
-    
-    @IBAction func letterButtonDidTap(_ sender: UIButton) {
-        hideComponents()
+        
         guard let letterOnboarding = UIStoryboard(name: Constant.Storyboard.Onboarding, bundle: nil).instantiateViewController(withIdentifier: Constant.ViewController.LetterOnboarding) as? LetterOnboardingViewController else { return }
         letterOnboarding.modalPresentationStyle = .overFullScreen
         letterOnboarding.modalTransitionStyle = .crossDissolve

--- a/Deartoday/Deartoday/Screen/Onboarding/Controller/OpenBoxOnboardingViewController.swift
+++ b/Deartoday/Deartoday/Screen/Onboarding/Controller/OpenBoxOnboardingViewController.swift
@@ -7,11 +7,12 @@
 
 import UIKit
 
-class OpenBoxOnboardingViewController: UIViewController {
+final class OpenBoxOnboardingViewController: UIViewController {
 
     // MARK: - UI Property
-    @IBOutlet var labelCollection: [UILabel]!
+    
     @IBOutlet weak var letterButton: UIButton!
+    @IBOutlet var labelCollection: [UILabel]!
     @IBOutlet weak var labelBottomConstraint: NSLayoutConstraint!
     
     // MARK: - Life Cycle
@@ -27,24 +28,17 @@ class OpenBoxOnboardingViewController: UIViewController {
     private func setLayout() {
         labelBottomConstraint.constant = (getDeviceHeight() == 667) ? 20 : 44
     }
-
-    // MARK: - Component UI Setting functions
     
     private func setUI() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             self.setComponentsAnimation()
         }
-        
         labelCollection.forEach {
             $0.textColor = .white
             $0.font = .p1
             $0.font = .systemFont(ofSize: 13)
-        }
-        
-        labelCollection.forEach {
             $0.isHidden = false
         }
-        
         letterButton.isHidden = false
     }
     

--- a/Deartoday/Deartoday/Screen/Onboarding/Controller/OpenBoxOnboardingViewController.swift
+++ b/Deartoday/Deartoday/Screen/Onboarding/Controller/OpenBoxOnboardingViewController.swift
@@ -42,6 +42,23 @@ final class OpenBoxOnboardingViewController: UIViewController {
         letterButton.isHidden = false
     }
     
+    private func hideComponents() {
+        labelCollection.forEach {
+            $0.isHidden = true
+        }
+        letterButton.isHidden = true
+    }
+    
+    // MARK: - IBAction
+    
+    @IBAction func letterButtonDidTap(_ sender: UIButton) {
+        hideComponents()
+        guard let letterOnboarding = UIStoryboard(name: Constant.Storyboard.Onboarding, bundle: nil).instantiateViewController(withIdentifier: Constant.ViewController.LetterOnboarding) as? LetterOnboardingViewController else { return }
+        letterOnboarding.modalPresentationStyle = .overFullScreen
+        letterOnboarding.modalTransitionStyle = .crossDissolve
+        present(letterOnboarding, animated: true)
+    }
+    
     // MARK: - Animation function
     
     private func setComponentsAnimation() {

--- a/Deartoday/Deartoday/Screen/Onboarding/Controller/OpenBoxOnboardingViewController.swift
+++ b/Deartoday/Deartoday/Screen/Onboarding/Controller/OpenBoxOnboardingViewController.swift
@@ -27,11 +27,10 @@ class OpenBoxOnboardingViewController: UIViewController {
     private func setLayout() {
         labelBottomConstraint.constant = (getDeviceHeight() == 667) ? 20 : 44
     }
-    
+
     // MARK: - Component UI Setting functions
     
     private func setUI() {
-        
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             self.setComponentsAnimation()
         }
@@ -72,3 +71,5 @@ class OpenBoxOnboardingViewController: UIViewController {
         })
     }
 }
+
+

--- a/Deartoday/Deartoday/Screen/Onboarding/Onboarding.storyboard
+++ b/Deartoday/Deartoday/Screen/Onboarding/Onboarding.storyboard
@@ -195,6 +195,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="labelBottomConstraint" destination="DWe-2G-lUv" id="AGW-2e-Gs4"/>
                         <outlet property="letterButton" destination="70R-xl-hYW" id="H5I-bb-DmM"/>
                         <outletCollection property="labelCollection" destination="HLl-Ah-hlx" collectionClass="NSMutableArray" id="72S-Fw-q30"/>
                         <outletCollection property="labelCollection" destination="CDM-6j-O6K" collectionClass="NSMutableArray" id="EBE-P0-CmL"/>

--- a/Deartoday/Deartoday/Screen/Onboarding/Onboarding.storyboard
+++ b/Deartoday/Deartoday/Screen/Onboarding/Onboarding.storyboard
@@ -7,6 +7,11 @@
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <array key="Pretendard-Medium.otf">
+            <string>Pretendard-Medium</string>
+        </array>
+    </customFonts>
     <scenes>
         <!--Onboarding View Controller-->
         <scene sceneID="s0d-6b-0kx">
@@ -31,7 +36,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="상자를 터치해서 안을 확인해 보세요." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZpD-nQ-Nlt">
+                            <label opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="상자를 터치해서 안을 확인해 보세요." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZpD-nQ-Nlt">
                                 <rect key="frame" x="93" y="719.33333333333337" width="187" height="15.666666666666629"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <nil key="textColor"/>
@@ -39,7 +44,7 @@
                             </label>
                             <button opaque="NO" alpha="0.0" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Fjd-0T-ndi">
                                 <rect key="frame" x="6" y="712" width="363" height="68"/>
-                                <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="18"/>
+                                <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="16"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="다음" backgroundImage="btnSmallPresent">
                                     <color key="titleColor" red="0.33333333333333331" green="0.5607843137254902" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -63,7 +68,7 @@
                                 </constraints>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <connections>
-                                    <action selector="boxButtonDidTap:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="JfW-MA-ClF"/>
+                                    <segue destination="roV-Nb-bde" kind="modal" modalPresentationStyle="fullScreen" modalTransitionStyle="crossDissolve" id="z4p-QV-zn7"/>
                                 </connections>
                             </button>
                             <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U2B-Nh-U49">
@@ -130,11 +135,82 @@
             </objects>
             <point key="canvasLocation" x="21.600000000000001" y="-133.00492610837438"/>
         </scene>
+        <!--Open Box Onboarding View Controller-->
+        <scene sceneID="BaI-zD-tIC">
+            <objects>
+                <viewController storyboardIdentifier="OpenBoxOnboarding" id="roV-Nb-bde" customClass="OpenBoxOnboardingViewController" customModule="Deartoday" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="XLR-Kd-n0y">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="image2Withg" translatesAutoresizingMaskIntoConstraints="NO" id="6ng-i4-D1d">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="의심스러운 눈초리로 상자를 여는 순간," textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HLl-Ah-hlx">
+                                <rect key="frame" x="86" y="597" width="202" height="15.666666666666629"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="의아한 당신은 상자 안에서 작은 편지를 발견합니다." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XHS-qE-BFB">
+                                <rect key="frame" x="54" y="652.33333333333337" width="266" height="15.666666666666629"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" alpha="0.0" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="70R-xl-hYW">
+                                <rect key="frame" x="6" y="712" width="363" height="68"/>
+                                <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="16"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="편지 읽어보기" backgroundImage="btnSmallPresent">
+                                    <color key="titleColor" red="0.33333333333333331" green="0.5607843137254902" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                </state>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="그 안에 들어있던 건 오랜만에 보는 비디오테이프와 플레이어." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CDM-6j-O6K">
+                                <rect key="frame" x="29" y="624.66666666666663" width="316" height="15.666666666666629"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="g3Q-ql-jle"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="g3Q-ql-jle" firstAttribute="trailing" secondItem="HLl-Ah-hlx" secondAttribute="trailing" constant="87" id="4Y4-Xu-vqD"/>
+                            <constraint firstItem="70R-xl-hYW" firstAttribute="top" secondItem="XHS-qE-BFB" secondAttribute="bottom" constant="44" id="DWe-2G-lUv"/>
+                            <constraint firstItem="g3Q-ql-jle" firstAttribute="trailing" secondItem="70R-xl-hYW" secondAttribute="trailing" constant="6" id="FnK-DC-iYR"/>
+                            <constraint firstItem="70R-xl-hYW" firstAttribute="bottom" secondItem="XLR-Kd-n0y" secondAttribute="bottom" constant="-32" id="GrP-TF-BUj"/>
+                            <constraint firstItem="g3Q-ql-jle" firstAttribute="trailing" secondItem="XHS-qE-BFB" secondAttribute="trailing" constant="55" id="Mea-bk-5M4"/>
+                            <constraint firstItem="70R-xl-hYW" firstAttribute="leading" secondItem="g3Q-ql-jle" secondAttribute="leading" constant="6" id="XZj-n0-PBR"/>
+                            <constraint firstItem="6ng-i4-D1d" firstAttribute="leading" secondItem="g3Q-ql-jle" secondAttribute="leading" id="YV4-WT-Sm9"/>
+                            <constraint firstItem="CDM-6j-O6K" firstAttribute="top" secondItem="HLl-Ah-hlx" secondAttribute="bottom" constant="12" id="YeD-hF-k3p"/>
+                            <constraint firstAttribute="bottom" secondItem="6ng-i4-D1d" secondAttribute="bottom" id="cgg-mN-YMS"/>
+                            <constraint firstItem="XHS-qE-BFB" firstAttribute="top" secondItem="CDM-6j-O6K" secondAttribute="bottom" constant="12" id="dmo-Yt-UFd"/>
+                            <constraint firstItem="CDM-6j-O6K" firstAttribute="leading" secondItem="g3Q-ql-jle" secondAttribute="leading" constant="29" id="hE8-rT-9J6"/>
+                            <constraint firstItem="6ng-i4-D1d" firstAttribute="top" secondItem="XLR-Kd-n0y" secondAttribute="top" id="hae-LW-V6S"/>
+                            <constraint firstItem="g3Q-ql-jle" firstAttribute="trailing" secondItem="6ng-i4-D1d" secondAttribute="trailing" id="rsp-hL-tnp"/>
+                            <constraint firstItem="XHS-qE-BFB" firstAttribute="leading" secondItem="g3Q-ql-jle" secondAttribute="leading" constant="54" id="tVD-Mn-HUp"/>
+                            <constraint firstItem="g3Q-ql-jle" firstAttribute="trailing" secondItem="CDM-6j-O6K" secondAttribute="trailing" constant="30" id="xc9-bd-oLP"/>
+                            <constraint firstItem="HLl-Ah-hlx" firstAttribute="leading" secondItem="g3Q-ql-jle" secondAttribute="leading" constant="86" id="zBC-Tb-GHj"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="letterButton" destination="70R-xl-hYW" id="H5I-bb-DmM"/>
+                        <outletCollection property="labelCollection" destination="HLl-Ah-hlx" collectionClass="NSMutableArray" id="72S-Fw-q30"/>
+                        <outletCollection property="labelCollection" destination="CDM-6j-O6K" collectionClass="NSMutableArray" id="EBE-P0-CmL"/>
+                        <outletCollection property="labelCollection" destination="XHS-qE-BFB" collectionClass="NSMutableArray" id="NKN-On-ZGq"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="of8-u7-yms" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="856.79999999999995" y="-133.00492610837438"/>
+        </scene>
     </scenes>
     <resources>
         <image name="btnCircleBasic" width="68" height="90"/>
         <image name="btnSmallPresent" width="57.666667938232422" height="68"/>
         <image name="image1Withg" width="375" height="812"/>
+        <image name="image2Withg" width="375" height="812"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Deartoday/Deartoday/Screen/Onboarding/Onboarding.storyboard
+++ b/Deartoday/Deartoday/Screen/Onboarding/Onboarding.storyboard
@@ -166,7 +166,7 @@
                                     <color key="titleColor" red="0.33333333333333331" green="0.5607843137254902" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 </state>
                                 <connections>
-                                    <segue destination="y6z-ac-w72" kind="presentation" modalPresentationStyle="overFullScreen" modalTransitionStyle="crossDissolve" id="96a-HZ-lcI"/>
+                                    <action selector="letterButtonDidTap:" destination="roV-Nb-bde" eventType="touchUpInside" id="GfA-M2-u1t"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="그 안에 들어있던 건 오랜만에 보는 비디오테이프와 플레이어." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CDM-6j-O6K">

--- a/Deartoday/Deartoday/Screen/Onboarding/Onboarding.storyboard
+++ b/Deartoday/Deartoday/Screen/Onboarding/Onboarding.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="roV-Nb-bde">
     <device id="retina5_9" orientation="portrait" appearance="dark"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
@@ -165,6 +165,9 @@
                                 <state key="normal" title="편지 읽어보기" backgroundImage="btnSmallPresent">
                                     <color key="titleColor" red="0.33333333333333331" green="0.5607843137254902" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 </state>
+                                <connections>
+                                    <segue destination="y6z-ac-w72" kind="presentation" modalPresentationStyle="overFullScreen" modalTransitionStyle="crossDissolve" id="96a-HZ-lcI"/>
+                                </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="그 안에 들어있던 건 오랜만에 보는 비디오테이프와 플레이어." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CDM-6j-O6K">
                                 <rect key="frame" x="29" y="624.66666666666663" width="316" height="15.666666666666629"/>
@@ -206,8 +209,36 @@
             </objects>
             <point key="canvasLocation" x="856.79999999999995" y="-133.00492610837438"/>
         </scene>
+        <!--Letter Onboarding View Controller-->
+        <scene sceneID="uQs-v0-wrz">
+            <objects>
+                <viewController storyboardIdentifier="LetterOnboardingViewController" modalPresentationStyle="overFullScreen" id="y6z-ac-w72" customClass="LetterOnboardingViewController" customModule="Deartoday" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="EQy-bI-g0g">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bgLetter" translatesAutoresizingMaskIntoConstraints="NO" id="1vr-xm-Zlx">
+                                <rect key="frame" x="0.0" y="156" width="375" height="656"/>
+                            </imageView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="aQg-fa-XZj"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="1vr-xm-Zlx" secondAttribute="bottom" id="4Gg-EO-vsR"/>
+                            <constraint firstItem="1vr-xm-Zlx" firstAttribute="leading" secondItem="aQg-fa-XZj" secondAttribute="leading" id="GZz-b6-BRk"/>
+                            <constraint firstItem="1vr-xm-Zlx" firstAttribute="top" secondItem="aQg-fa-XZj" secondAttribute="top" constant="112" id="h54-FX-d33"/>
+                            <constraint firstItem="aQg-fa-XZj" firstAttribute="trailing" secondItem="1vr-xm-Zlx" secondAttribute="trailing" id="naF-FY-3qz"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="P1B-bh-UwF"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="3kI-pV-Szm" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1710" y="-133"/>
+        </scene>
     </scenes>
     <resources>
+        <image name="bgLetter" width="375" height="652"/>
         <image name="btnCircleBasic" width="68" height="90"/>
         <image name="btnSmallPresent" width="57.666667938232422" height="68"/>
         <image name="image1Withg" width="375" height="812"/>


### PR DESCRIPTION
## 🌱 작업한 내용

- 로티 다음 애니메이션 구현
- 편지 화면 전환 구현

## 🌱 PR Point

- 에셋을 수정해야 돼서 편지 화면 전환까지만 하고 애니메이션 구현은 아직 안 했습니다
- 코드가 좀 간결해졌을까요 ...?? 경만시랑 소연시 코드 보면서 구현해 봣어요 ... ...

## 📸 스크린샷

표가 좋은 나 ^_________^ 깔끔하게 보여드릴게요.

|로티 다음 온보딩 | 온보딩 편지 UI |
|------|--------|
| ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-07-14 at 02 59 29](https://user-images.githubusercontent.com/86944161/178800101-5cb966db-aabb-4740-b58e-1ddf19209d44.png)| ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-07-14 at 02 59 35](https://user-images.githubusercontent.com/86944161/178800202-13b93544-a2af-4aed-8e93-3fd2ad146aab.png)|

아놔 이거 쓰다가 편지 뒤에 라벨이랑 버튼 hidden 처리 안 한 거 알아버림.


## 📮 관련 이슈

- Resolved: #38 
